### PR TITLE
Add setup-vyos-build-pkg for submodule build.

### DIFF
--- a/README
+++ b/README
@@ -30,7 +30,6 @@ Build Host Setup
       live-helper    # Required, for ISO build
       syslinux       # Required, for ISO build
       genisoimage    # Required, for ISO build
-      make           # Required, for ISO build
       ssh            # Optional, for cloning over SSH
       sudo           # Optional, ISO build requires root privileges
 

--- a/tools/setup-vyos-build-env
+++ b/tools/setup-vyos-build-env
@@ -9,7 +9,7 @@ if [ ${UID} -ne 0 ] ; then
 fi
 
 apt-get install -y git autoconf dpkg-dev live-helper syslinux genisoimage \
-                   ssh sudo devscripts
+                   ssh sudo
 wget -O - $VYOS_PUBKEY_URL  | apt-key add -
 echo "deb $DEBIAN_BP_URL squeeze-backports main" \
       > /etc/apt/sources.list.d/squeeze-backports.list

--- a/tools/setup-vyos-build-pkg
+++ b/tools/setup-vyos-build-pkg
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+VYOS_PUBKEY_URL="http://packages.vyos.net/vyos-pubkey.gpg"
+DEBIAN_BP_URL="http://backports.debian.org/debian-backports"
+
+if [ ${UID} -ne 0 ] ; then
+  echo "This command needs to be run as root."
+  exit 1
+fi
+
+wget -O - $VYOS_PUBKEY_URL  | apt-key add -
+echo "deb $DEBIAN_BP_URL squeeze-backports main" \
+      > /etc/apt/sources.list.d/squeeze-backports.list
+
+apt-get update
+apt-get -t squeeze-backports install -y squashfs-tools
+
+apt-get install -y \
+  autoconf \
+  autogen \
+  bison \
+  cdbs \
+  devscripts \
+  dpkg-dev \
+  flex \
+  gawk \
+  gcc-multilib \
+  genisoimage \
+  git \
+  hardening-wrapper \
+  iptables-dev \
+  kernel-package \
+  libapt-pkg-dev \
+  libatm1-dev \
+  libattr1-dev \
+  libboost-filesystem1.42-dev \
+  libc6-dev-i386 \
+  libcap-dev \
+  libcap2-dev \
+  libcurl4-openssl-dev \
+  libdb-dev \
+  libdb4.8-dev \
+  libdumbnet-dev \
+  libedit-dev \
+  libexpat1-dev \
+  libgcrypt11-dev \
+  libglib2.0-dev \
+  libgmp3-dev \
+  libkrb5-dev \
+  libldap2-dev \
+  liblzo2-dev \
+  libncurses5-dev \
+  libnetfilter-conntrack-dev \
+  libnfnetlink-dev \
+  libopensc2-dev \
+  libpam0g-dev \
+  libpcap0.8-dev \
+  libpci-dev \
+  libperl-dev \
+  libpopt-dev \
+  libproc-dev \
+  libreadline5-dev \
+  libsensors4-dev \
+  libsnmp-dev \
+  libssl-dev \
+  libtool \
+  libwrap0-dev \
+  libxml2-dev \
+  live-helper \
+  python-all-dev \
+  python-setuptools \
+  quilt \
+  ruby \
+  ssh \
+  sudo \
+  syslinux \
+  unifont \
+  zlib1g-dev \
+


### PR DESCRIPTION
Separate two scripts. 
- setup-vyos-build-pkg: install packages for submodules build
- setup-vyos-build-env: install packages for build iso image.

The following submodules can't build properly yet. 

libczmq
libmnl
libnetfilter-conntrack
libnetfilter-cthelper
libnetfilter-queue
open-vm-tools
vyatta-op-dhcp-server
vyatta-op-vpn
