### PR TITLE
Bug#200 revese commit #c5f1546, overlayfs not ready yet.

### DIFF
--- a/livecd/config.vyatta/chroot_local-includes/etc/live.conf
+++ b/livecd/config.vyatta/chroot_local-includes/etc/live.conf
@@ -6,6 +6,6 @@ export QUICKREBOOT=yes
 export NOXAUTOCONFIG=yes
 export NORESTRICTEDMANAGER=yes
 export NOUPDATENOTIFIER=yes
-export UNIONTYPE=overlayfs
+export UNIONTYPE=unionfs
 export NOAPTCDROM=yes
 export NOCONSOLEKEYBOARD=yes


### PR DESCRIPTION
From Kim comment.
http://bugzilla.vyos.net/show_bug.cgi?id=200

Kernel for helium is still set to 3.3.8 and this has no overlayfs in it,
that is why it will not boot "yet" when it is set to kernel 3.13 i will work.

I think for now your best option is to reverse the commit i made untill
we make the kernel switch.
