### PR TITLE
build-iso: update README build requirements for some packages

### DIFF
--- a/README
+++ b/README
@@ -37,6 +37,7 @@ Build Host Setup
       fakechroot      # Required, for ISO build
       devscripts      # Optional, for building submodules (kernel etc)
       kernel-package  # Optional, for building the kernel
+      libtool         # Optional, for building certain packages (eg vyatta-op-vpn)
 
     Now install the VyOS package repository GPG key.
 


### PR DESCRIPTION
Added one additional (optional) package to the build requirements list
in the README file, required for building packages like vyatta-op-vpn.

Bug #279 http://bugzilla.vyos.net/show_bug.cgi?id=279
